### PR TITLE
rules: main is closed, the reviewer's comments are work; tools selftest in CI

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit for dew_flow_conventions — the family's shared Claude Code rules (markdown) and the
+# small node tools that enforce them (tools/*.mjs, run in every consumer's CI).
+language: "ru-RU"
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "main"
+  path_filters:
+    - "!**/node_modules/**"
+    - "!tools/fixtures/**"
+  path_instructions:
+    - path: "common/**/*.md"
+      instructions: |
+        These are rules loaded into every Claude Code session across the dew_flow family. Review for:
+        a rule that contradicts another rule in common/; a MANDATORY rule with no Definition of Done
+        section; a rule that names a file, flag or tool that does not exist in the family; a rule whose
+        measured claim carries no date or source. The narrative style (dated observations, "measured
+        here on …") is deliberate — do not flag it. A rule change is not complete without the consumer
+        pin bumps (README.md, Editing discipline); say so if the PR description does not mention them.
+    - path: "tools/*.mjs"
+      instructions: |
+        Node ESM run in CI on Linux and Windows: no shell globs (a glob was the bug twice), paths built
+        with node:path, exit code 1 with a named finding on failure and 0 with the finding printed on
+        success. Every tool has a case in tools/selftest.test.mjs.
+  tools:
+    gitleaks:
+      enabled: true
+    actionlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    markdownlint:
+      enabled: false
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  opt_out: false
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "README.md"
+      - "common/**/*.md"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  tools:
+    name: tools · selftest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      # The tools that every consumer's CI runs (plan-lifecycle, pin-check, gate-snippet-check,
+      # http-coverage, post-deploy-check) test themselves against tools/fixtures. A tool that
+      # breaks here breaks every consumer's build on its next pin bump, so it is checked here first.
+      - name: Selftest
+        run: node --test tools/selftest.test.mjs

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ of skipping it is a commit that breaks a rule written precisely because breaking
   consumers two commits behind — one missing `gpu-lease.md` entirely — which is why the pin has a
   check instead of an owner.
 - Repo-specific rules stay in the consumer's own `.claude/rules/` beside `shared/`.
+- **`main` is closed, here and in every consumer that protects it.** A change is a branch and a pull
+  request, merged by rebase or squash; the automated reviewer's comments are verified and then fixed or
+  answered before the merge — [common/pull-requests.md](common/pull-requests.md).
 
 ## Consumers
 

--- a/common/git-workflow.md
+++ b/common/git-workflow.md
@@ -1,5 +1,9 @@
 # Git Workflow
 
+> How a commit REACHES `main` — a pull request, the automated reviewer's comments verified and
+> answered, a rebase or squash merge — is [pull-requests.md](pull-requests.md). This file governs the
+> commit itself.
+
 ## Commit your OWN work, and only after it is verified (MANDATORY)
 
 Superseded 2026-08-16 the earlier rule that a commit should cover *everything* `git status` shows. That

--- a/common/pull-requests.md
+++ b/common/pull-requests.md
@@ -1,0 +1,70 @@
+# Pull requests — `main` is closed; the reviewer's comments are work (MANDATORY)
+
+> Extends [git-workflow.md](git-workflow.md), which governs the COMMIT. This rule governs how a commit
+> reaches `main`, and what an automated reviewer's comments oblige you to do. Adopted 2026-09-05 when
+> CodeRabbit was connected to the public repositories of this family and `main` was protected on them.
+
+## The rule
+
+1. **Nothing is pushed to `main`.** Not by an agent, not by the operator, not by an admin — the branch
+   protection enforces it for admins too. Every change is a branch and a pull request, merged by
+   **rebase** (linear history; each commit keeps the message it was written with) or by **squash** when
+   a branch is a trail of fix-ups nobody should read. Merge commits are off.
+2. **A pull request is not done when it is opened.** After opening it, come back **about five minutes
+   later** and read what arrived: the CI checks, and — where the repository has an automated reviewer
+   (CodeRabbit on `dew_flow_connect_other_ais`, `dew_flow_conventions`, `dew_flow_creds_for_devs`) —
+   its summary and every inline comment.
+3. **Verify a reviewer's comment before acting on it.** An automated reviewer is a colleague who has
+   not run the code. For each comment, first establish whether it is **accurate** (does the code do
+   what the comment says?) and **right** (does this repository's rule agree — `CLAUDE.md`,
+   `.claude/rules/**`?). Then exactly one of:
+   - it is accurate and right → fix it, in a commit on the same branch, and say so in the thread;
+   - it is inaccurate or contradicts a rule → reply in the thread with the reason, citing the code or
+     the rule, and resolve it. A comment answered with silence is a comment somebody will re-raise.
+4. **Every thread is resolved before the merge.** The protection requires conversation resolution; the
+   reply above is what resolves it honestly. Resolving a thread without a fix or a reason is the one
+   forbidden move.
+5. **The pull request description is the record.** What was asked, what shipped, what the tests
+   showed (observed output, not "tests pass"), and what the automated reviewer said that was NOT acted
+   on and why. The merge commit — rebase or squash — carries that text into `main`'s history.
+6. **Releases still start from tags** (`mcp-v*`, `extension-v*`, `server-v*`), cut on `main` **after**
+   the merge, never on a branch.
+
+## For an agent working autonomously
+
+The *Work autonomously* order of the review gate names this: open the pull request, wait, read,
+verify, fix or answer, resolve, merge, tag. An agent that opens a pull request and moves on has done
+half the work and left the other half to the person it was meant to spare.
+
+```bash
+gh pr create --fill --base main            # open
+sleep 300                                   # let CI and the reviewer arrive
+gh pr view --comments                       # read the summary and the threads
+gh api repos/{owner}/{repo}/pulls/{n}/comments   # every inline comment, with its path and line
+# fix or reply per thread, then:
+gh pr merge --rebase --delete-branch        # or --squash for a fix-up trail
+```
+
+## Never
+
+- Never push to `main`, and never disable the protection to do it "just this once".
+- Never resolve a reviewer's thread without a fix or a written reason.
+- Never act on a comment you have not checked against the code and the rules — an automated reviewer
+  is confidently wrong at a steady rate, and "the bot said so" is not a reason to change working code.
+- Never merge with a red check or an open thread.
+
+## Definition of Done
+
+- [ ] The change reached `main` through a pull request merged by rebase or squash.
+- [ ] About five minutes after opening, the CI checks and the reviewer's comments were read.
+- [ ] Every reviewer comment was verified against the code and the rules, then fixed or answered in
+      the thread, and the thread resolved.
+- [ ] The pull request description records what shipped, what the tests showed, and what was not acted
+      on and why.
+- [ ] Any release tag was cut on `main` after the merge.
+
+## Mirrors
+
+This is a shared rule; consumers mount it through the `.claude/rules/shared` submodule. Repositories
+with an automated reviewer today: `dew_flow_connect_other_ais`, `dew_flow_conventions`,
+`dew_flow_creds_for_devs`. Adding one to another repository is a one-line change to the list above.


### PR DESCRIPTION
Adopted 2026-09-05 when CodeRabbit was connected to the family's public repositories and `main` was
protected on them (pull request only, admins included; linear history; every thread resolved).

* common/pull-requests.md — the rule: nothing is pushed to main; a pull request is re-read about
  five minutes after it is opened; every automated-reviewer comment is VERIFIED against the code and
  the repository's rules before it is acted on, then fixed or answered in the thread; nothing merges
  with an open thread or a red check; the description is the record; tags are cut on main after the
  merge. git-workflow.md points at it; README's editing discipline names it.
* .coderabbit.yaml — the reviewer configured for this repository: Russian summaries, the chill
  profile, no poem, path instructions for the rules and for the tools, gitleaks and actionlint on.
* .github/workflows/ci.yml — this repository had no CI. The tools every consumer runs now test
  themselves here on every pull request (node --test tools/selftest.test.mjs), so a tool that
  breaks is caught before its next pin bump breaks six builds.

This pull request is also the first check that the reviewer is actually connected.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)