### PR TITLE
ci: dependabot for the actions, a pull request template, and semantic titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Dependabot version updates. This repository has no package manifests — the tools use node's
+# built-ins only — so the one ecosystem to watch is the actions its CI runs on.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Kyiv"
+    groups:
+      actions:
+        patterns: ["*"]
+    labels: ["dependencies", "ci"]
+    commit-message:
+      prefix: "ci(deps)"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+<!-- The title is the changelog line: `type: what changed` — feat, fix, docs, test, chore, refactor, perf, ci, build. -->
+
+## What changed, and why
+
+<!-- Which rule, what it said, what it says now — and the observation that made the change necessary. -->
+
+## Evidence
+
+- [ ] `node --test tools/selftest.test.mjs` ran, and this is what it printed:
+
+```
+<paste the summary lines>
+```
+
+## The cascade
+
+- [ ] **A rule change and the pin bumps are one task** (README, Editing discipline): the consumer pull requests that bump `.claude/rules/shared` are listed here, or the reason none is needed.
+
+## The reviewer
+
+<!-- Filled in about five minutes after opening: what CodeRabbit said, what was fixed, and what was NOT acted on — with the reason. -->

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,32 @@
+name: pr · title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic:
+    name: pr · semantic title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            test
+            chore
+            refactor
+            perf
+            ci
+            build
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" starts with a capital letter; the family writes `type: lower-case what changed`.


### PR DESCRIPTION
The family's hardening list of 2026-09-05, epic 3, for the rules repository: Dependabot watches the
actions its CI runs on (there are no package manifests here); the template asks for the selftest
output and for the consumer pin bumps a rule change owes; the title check keeps main's history in
the family's shape.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)