### PR TITLE
ci: SonarCloud analysis of the tools

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,30 @@
+name: sonarcloud
+
+# SonarCloud analysis of the node tools with the generic scanner; there is no .NET here. The
+# selftest runs in ci.yml; this job is the static analysis only.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: sonarcloud-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sonar:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.projectKey=remsoftdev_dew_flow_conventions
+sonar.organization=remsoftdev
+sonar.projectName=dew_flow_conventions
+# The tools every consumer runs, and their selftest. The rules themselves are markdown and are not
+# analysed; the fixtures are inputs to the tests, not code of this repository.
+sonar.sources=tools
+sonar.tests=tools
+sonar.test.inclusions=tools/**/*.test.mjs
+sonar.exclusions=tools/fixtures/**,**/node_modules/**
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Project remsoftdev_dew_flow_conventions, created 2026-09-05; the generic scanner over tools/, the
selftest declared as tests and the fixtures excluded. The rules are markdown and are not analysed.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)