### PR TITLE
fix: a path a flag names must stay inside the repository; the sorts say how they sort

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -24,6 +24,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      # The gate measures coverage of NEW code, so the scan needs a report rather than a promise.
+      # Node's own runner produces lcov; the selftest is the only test there is.
+      - name: Test with coverage
+        run: |
+          mkdir -p coverage
+          node --test --experimental-test-coverage --test-reporter=lcov                --test-reporter-destination=coverage/lcov.info tools/selftest.test.mjs
       - uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage/

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,3 +8,6 @@ sonar.tests=tools
 sonar.test.inclusions=tools/**/*.test.mjs
 sonar.exclusions=tools/fixtures/**,**/node_modules/**
 sonar.sourceEncoding=UTF-8
+# Coverage of the tools, from node's own test runner (--experimental-test-coverage, lcov reporter).
+# The selftest is the only test there is, and it is what the gate's new-code coverage is measured on.
+sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/tools/http-coverage.mjs
+++ b/tools/http-coverage.mjs
@@ -32,6 +32,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { within } from "./lib/paths.mjs";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
@@ -173,14 +174,14 @@ function defaultSources(root) {
 function main() {
   const { values: flags } = parseArgs({ options });
   const root = process.cwd();
-  const httpRoot = path.resolve(root, flags.http);
+  const httpRoot = within(root, flags.http, "--http");
 
   let routes;
   if (flags.routes) {
-    routes = loadRouteTable(path.resolve(root, flags.routes));
+    routes = loadRouteTable(within(root, flags.routes, "--routes"));
     console.log(`http-coverage: ${routes.length} route(s) from ${flags.routes} (the application's own table).`);
   } else {
-    const sources = (flags.source.length > 0 ? flags.source.map((s) => path.resolve(root, s)) : defaultSources(root))
+    const sources = (flags.source.length > 0 ? flags.source.map((s) => within(root, s, "--source")) : defaultSources(root))
       .filter((dir) => fs.existsSync(dir));
     const files = sources.flatMap((dir) => walkSources(dir));
     routes = files.flatMap((file) => scanRoutes(fs.readFileSync(file, "utf8"), path.relative(root, file)));

--- a/tools/http-run.mjs
+++ b/tools/http-run.mjs
@@ -35,6 +35,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { within } from "./lib/paths.mjs";
 import { createRequire } from "node:module";
 import { parseArgs } from "node:util";
 
@@ -126,7 +127,7 @@ async function main() {
   }
   const flags = parsed.values;
   const root = process.cwd();
-  const suiteRoot = path.resolve(root, parsed.positionals[0] ?? "http");
+  const suiteRoot = within(root, parsed.positionals[0] ?? "http", "suite root");
 
   // A secret the suite needs and does not have is CONFIGURATION, and saying so here is the only
   // place it can still be said plainly: once the run starts, a missing token arrives as a wall of
@@ -150,7 +151,7 @@ async function main() {
     return EXIT.configurationError;
   }
 
-  const artifacts = path.resolve(root, flags.artifacts);
+  const artifacts = within(root, flags.artifacts, "--artifacts");
   fs.mkdirSync(artifacts, { recursive: true });
   const reportPath = path.join(artifacts, "report.xml");
   fs.rmSync(reportPath, { force: true }); // never read a report you did not just produce

--- a/tools/lib/paths.mjs
+++ b/tools/lib/paths.mjs
@@ -1,0 +1,27 @@
+/**
+ * A path a CLI flag named, resolved and REQUIRED to stay inside the repository it is run against.
+ *
+ * Every tool here takes paths from its arguments — a suite root, an artifacts directory, a route
+ * table, a checklist — resolves them and then reads, writes or in one case `rm -rf`s them. SonarCloud
+ * (S8707, 2026-09-05) put it plainly: a path canonicalised from CLI-controlled data must be validated
+ * before use, and "LLMs running this code with faulty CLI arguments can escape file system
+ * restrictions". An agent IS the usual caller of these tools. So there is one door: a path either
+ * resolves under `root`, or the tool stops with a named finding before touching anything.
+ */
+import * as path from "node:path";
+
+/**
+ * `candidate` resolved against `root`, or an Error naming both when it would leave `root`.
+ *
+ * `root` itself is allowed (`within(root, ".")` is `root`); a parent, a sibling or an absolute path
+ * elsewhere is not. A symlink that escapes is not followed here — the check is lexical, which is
+ * what the finding asked for and what a CI run over its own checkout needs.
+ */
+export function within(root, candidate, what = "path") {
+  const base = path.resolve(root);
+  const resolved = path.resolve(base, candidate);
+  if (resolved !== base && !resolved.startsWith(base + path.sep)) {
+    throw new Error(`${what} "${candidate}" resolves to ${resolved}, outside the repository ${base}`);
+  }
+  return resolved;
+}

--- a/tools/plan-lifecycle.mjs
+++ b/tools/plan-lifecycle.mjs
@@ -93,7 +93,7 @@ const OPEN_SECTION = /^##\s+Currently open\s*$/im;
 const isPlan = (name) => /^PLAN_[A-Za-z0-9_]+\.md$/.test(name);
 
 const plansIn = (dir) =>
-  fs.existsSync(dir) ? fs.readdirSync(dir).filter(isPlan).sort() : [];
+  fs.existsSync(dir) ? fs.readdirSync(dir).filter(isPlan).sort((a, b) => a.localeCompare(b)) : [];
 
 const markdownIn = (dir) =>
   fs.existsSync(dir) ? fs.readdirSync(dir).filter((f) => f.endsWith(".md")).sort() : [];
@@ -154,7 +154,7 @@ function openSectionRows(readme) {
 
   return {
     found: true,
-    rows: [...section.matchAll(INDEX_ROW)].map((m) => m[1]).sort(),
+    rows: [...section.matchAll(INDEX_ROW)].map((m) => m[1]).sort((a, b) => a.localeCompare(b)),
   };
 }
 
@@ -285,7 +285,7 @@ function main() {
   }
 
   console.error(`plan-lifecycle: ${findings.length} finding(s) — see common/planning-docs.md\n`);
-  for (const finding of findings.sort()) console.error(`  ${finding}`);
+  for (const finding of findings.sort((a, b) => a.localeCompare(b))) console.error(`  ${finding}`);
   console.error("\nPromote a finished plan with /promote-plan; it performs the whole move in one pass.");
   return 1;
 }

--- a/tools/post-deploy-check.mjs
+++ b/tools/post-deploy-check.mjs
@@ -31,6 +31,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { within } from "./lib/paths.mjs";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
@@ -165,7 +166,7 @@ async function runItems(items, target, timeoutMs) {
 
 async function main() {
   const { values: flags } = parseArgs({ options });
-  const file = path.resolve(process.cwd(), flags.file);
+  const file = within(process.cwd(), flags.file, "--file");
 
   if (!fs.existsSync(file)) {
     console.log(`post-deploy-check: ${flags.file} is missing.`);

--- a/tools/selftest.test.mjs
+++ b/tools/selftest.test.mjs
@@ -372,3 +372,20 @@ test("a repository that mounts no rule has nothing to check, and says so rather 
     fs.rmSync(empty, { recursive: true, force: true });
   }
 });
+
+// ---------- lib/paths.mjs: a flag cannot name a path outside the repository ----------
+import { within } from "./lib/paths.mjs";
+import * as pathForWithin from "node:path";
+
+test("within: a relative path under the root resolves, the root itself is allowed", () => {
+  const root = pathForWithin.resolve("tools", "fixtures");
+  assert.equal(within(root, "repo/http"), pathForWithin.join(root, "repo", "http"));
+  assert.equal(within(root, "."), root);
+});
+
+test("within: a parent, a sibling and an absolute path elsewhere are refused by name", () => {
+  const root = pathForWithin.resolve("tools", "fixtures");
+  for (const bad of ["..", "../selftest.test.mjs", pathForWithin.resolve("tools")]) {
+    assert.throws(() => within(root, bad, "--artifacts"), /--artifacts .* outside the repository/);
+  }
+});


### PR DESCRIPTION
SonarCloud on the first analysis of this repository, 2026-09-05: fifteen S8707 findings — "a path
canonicalized from CLI-controlled data must be validated before use; LLMs running this code with
faulty CLI arguments can escape file system restrictions" — and an agent is the usual caller of
these tools. One of the sites was an rm -rf of a directory named by --artifacts.

tools/lib/paths.mjs is the one door: within(root, candidate, what) resolves a flag against the
repository root and stops with a named finding when the result would leave it. http-run (suite root,
--artifacts), http-coverage (--http, --routes, --source) and post-deploy-check (--file) go through
it; plan-lifecycle's paths all derive from the root it is given. Two S2871 bugs — .sort() with no
comparator — get localeCompare. The three S4036 PATH findings are resolved in SonarCloud as won't
fix with the reason: the tools run git and node from the CI runner's PATH by design.

Selftest: 41 passing (two new).

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)