### PR TITLE
feat: the diff goes through the gate before the pull request

### DIFF
--- a/common/pull-requests.md
+++ b/common/pull-requests.md
@@ -10,24 +10,42 @@
    protection enforces it for admins too. Every change is a branch and a pull request, merged by
    **rebase** (linear history; each commit keeps the message it was written with) or by **squash** when
    a branch is a trail of fix-ups nobody should read. Merge commits are off.
-2. **A pull request is not done when it is opened.** After opening it, come back **about five minutes
+2. **The diff goes through the review gate BEFORE the pull request is opened.** Where the repository
+   has the `coai` gate ([coai-review-gate.md](coai-review-gate.md)), the change is not ready for a
+   pull request until `review_code` has run over its diff and every finding has been resolved —
+   accepted and fixed, or rejected with a reason. The gate is not a nicer code review; it is other
+   vendors' models reading the change without your context, and it is the one reader that has not
+   already agreed with you.
+
+   **The order is: plan → gate → implement → gate → pull request.** Opening the pull request first
+   and running the gate "later" is the same mistake as writing the test after the fix: by then the
+   diff is a thing you are defending rather than a thing you are checking. Measured here on
+   2026-09-05, and it is why this clause exists: an agent landed more than twenty pull requests in
+   one session, every one of them through CI and an automated reviewer, and not one of them through
+   the gate that repository ships.
+
+   A change with no diff to review — a documentation-only edit, a version bump, a workflow the gate
+   cannot run against — says so in the pull request description instead. "Not applicable" written
+   down is a decision; silence is an omission.
+
+3. **A pull request is not done when it is opened.** After opening it, come back **about five minutes
    later** and read what arrived: the CI checks, and — where the repository has an automated reviewer
    (CodeRabbit on `dew_flow_connect_other_ais`, `dew_flow_conventions`, `dew_flow_creds_for_devs`) —
    its summary and every inline comment.
-3. **Verify a reviewer's comment before acting on it.** An automated reviewer is a colleague who has
+4. **Verify a reviewer's comment before acting on it.** An automated reviewer is a colleague who has
    not run the code. For each comment, first establish whether it is **accurate** (does the code do
    what the comment says?) and **right** (does this repository's rule agree — `CLAUDE.md`,
    `.claude/rules/**`?). Then exactly one of:
    - it is accurate and right → fix it, in a commit on the same branch, and say so in the thread;
    - it is inaccurate or contradicts a rule → reply in the thread with the reason, citing the code or
      the rule, and resolve it. A comment answered with silence is a comment somebody will re-raise.
-4. **Every thread is resolved before the merge.** The protection requires conversation resolution; the
+5. **Every thread is resolved before the merge.** The protection requires conversation resolution; the
    reply above is what resolves it honestly. Resolving a thread without a fix or a reason is the one
    forbidden move.
-5. **The pull request description is the record.** What was asked, what shipped, what the tests
+6. **The pull request description is the record.** What was asked, what shipped, what the tests
    showed (observed output, not "tests pass"), and what the automated reviewer said that was NOT acted
    on and why. The merge commit — rebase or squash — carries that text into `main`'s history.
-6. **Releases still start from tags** (`mcp-v*`, `extension-v*`, `server-v*`), cut on `main` **after**
+7. **Releases still start from tags** (`mcp-v*`, `extension-v*`, `server-v*`), cut on `main` **after**
    the merge, never on a branch.
 
 > What the reviewer and the scanners REPORT — and the obligation to bring it to zero, or to ask when a
@@ -58,6 +76,8 @@ gh pr merge --rebase --delete-branch        # or --squash for a fix-up trail
 
 ## Definition of Done
 
+- [ ] The diff went through the `coai` gate before the pull request was opened, and every finding was
+      resolved — or the description says why the gate does not apply to this change.
 - [ ] The change reached `main` through a pull request merged by rebase or squash.
 - [ ] About five minutes after opening, the CI checks and the reviewer's comments were read.
 - [ ] Every reviewer comment was verified against the code and the rules, then fixed or answered in


### PR DESCRIPTION
The gate rule says a repository is reviewed before and after implementation. The pull-request rule —
the one an agent actually follows when landing a change — said nothing about it, so the two never
met: an agent could satisfy every word of both while never running the gate on the thing it was
about to merge.

Measured here on 2026-09-05, which is why the clause names it: more than twenty pull requests landed
in one session, every one through CI and an automated reviewer, not one through the gate that
repository ships. The order is plan → gate → implement → gate → pull request; opening first and
gating later is the same mistake as writing the test after the fix.

A change the gate cannot read — docs, a version bump, a workflow — says so in the description. Not
applicable, written down, is a decision; silence is an omission.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)